### PR TITLE
OAuth Integration

### DIFF
--- a/donald.conf.example
+++ b/donald.conf.example
@@ -11,7 +11,7 @@
 		"channel": "#oddr"
 	},
 	"twitter": {
-		"interval": "",
+		"interval": "15",
 		"oauth_key": "",
 		"oauth_secret": ""
 	},

--- a/donald.conf.example
+++ b/donald.conf.example
@@ -11,8 +11,9 @@
 		"channel": "#oddr"
 	},
 	"twitter": {
-		"email": "you@domain.com",
-		"password": "p@$$w0rd"
+		"interval": "",
+		"oauth_key": "",
+		"oauth_secret": ""
 	},
 	"options": {
 		"display_self_tweets": false,

--- a/donald.py
+++ b/donald.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python2.6
 """
 donald
 
@@ -79,12 +80,20 @@ class TwitterState(object):
 	
 	def oauth_init(self):
 		#initializes OAuth token, returns token and secret.  should only be called externally
-		twitterConnect = twitter.Twitter(auth=twitter.oauth.OAuth('','',self.CONSUMER_KEY,self.CONSUMER_SECRET),api_version=None,format='')
-		oauth_token, oauth_token_secret = twitter.oauth_dance.parse_oauth_tokens(twitterConnect.oauth.request_token())
+		try: 
+			twitterConnect = twitter.Twitter(auth=twitter.oauth.OAuth('','',self.CONSUMER_KEY,self.CONSUMER_SECRET),api_version=None,format='')
+			oauth_token, oauth_token_secret = twitter.oauth_dance.parse_oauth_tokens(twitterConnect.oauth.request_token())
+		except:
+			print >> sys.stderr, "Problem connecting to Twitter.  Is Twitter having issues?"
+			sys.exit(1)
 		print "To allow access to your Twitter account, please visit the following URL and click 'Accept':\r\nhttp://api.twitter.com/oauth/authorize?oauth_token=%s" % oauth_token
 		oauth_token_pin = raw_input("Enter PIN: ")
-		twitterConnect = twitter.Twitter(auth=twitter.oauth.OAuth(oauth_token,oauth_token_secret,self.CONSUMER_KEY,self.CONSUMER_SECRET),api_version=None,format='')
-		oauth_token, oauth_token_secret = twitter.oauth_dance.parse_oauth_tokens(twitterConnect.oauth.access_token(oauth_verifier=oauth_token_pin))
+		try: 
+			twitterConnect = twitter.Twitter(auth=twitter.oauth.OAuth(oauth_token,oauth_token_secret,self.CONSUMER_KEY,self.CONSUMER_SECRET),api_version=None,format='')
+			oauth_token, oauth_token_secret = twitter.oauth_dance.parse_oauth_tokens(twitterConnect.oauth.access_token(oauth_verifier=oauth_token_pin))
+		except: 
+			print >> sys.stderr, "Error adding key.  Did you enter the correct PIN?"
+			sys.exit(1)
 		return oauth_token, oauth_token_secret
 
 	def reset_state(self):

--- a/donald.py
+++ b/donald.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python2.6
 """
 donald
 


### PR DESCRIPTION
Submitting again with exception handling in TwitterState.oauth_init()
~~
OAuth has been fully integrated.

The first time donald.py is run, you'll see this:

```zach@konami:~/donald$ ./donald.py
To allow access to your Twitter account, please visit the following URL and click 'Accept':
http://api.twitter.com/oauth/authorize?oauth_token=q20fh02hfg092hf0hf9023hf02h
Enter PIN: awlgklwjklwejklwejflwj
Key added.  Run donald.py again to activate bot.```

Issues:
- Custom order in the donald.conf file won't be preserved when the oauth key and secret are written (obviously, dict() types aren't ordered)
- Edit: the deprecation bug has been fixed in the latest version of Mike Verdone's Twitter library.